### PR TITLE
Generate helpers to make constructing and accessing oneof fields easier

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1948,6 +1948,28 @@ func (f *oneofField) getter(g *Generator, mc *msgCtx) {
 		g.P("}")
 		g.P()
 	}
+
+	// Must getters for each oneof
+	for _, sf := range f.subFields {
+		if sf.deprecated != "" {
+			g.P(sf.deprecated)
+		}
+		g.P("func (m *", mc.goName, ") ", Annotate(mc.message.file, sf.fullPath, fmt.Sprintf("Must%s", sf.getterName)), "() "+sf.goType+" {")
+		g.P("return m.", f.getterName, "().(*", sf.oneofTypeName, ").", sf.goName)
+		g.P("}")
+		g.P()
+	}
+
+	// Constructors for each oneof
+	for _, sf := range f.subFields {
+		if sf.deprecated != "" {
+			g.P(sf.deprecated)
+		}
+		g.P("func New", sf.oneofTypeName, "(x ", sf.goType, ") *", mc.goName, "{")
+		g.P("return &", mc.goName, "{", f.goName, ": &", sf.oneofTypeName, "{x}}")
+		g.P("}")
+		g.P()
+	}
 }
 
 // setter prints the setter method of the field.


### PR DESCRIPTION
The existing code generation produces code like this: 

`func (m *Metadata) GetTest() string {
	if x, ok := m.GetValue().(*Metadata_Test); ok {
		return x.Test
	}
	return ""
}`

This change adds the following:

`func (m *Metadata) MustGetTest() string {
	return m.GetValue().(*Metadata_Test).Test
}`

`func NewMetadata_Test(x string) *Metadata {
	return &Metadata{Value: &Metadata_Test{x}}
}`